### PR TITLE
Recurse into submodules with git

### DIFF
--- a/lib/travis/worker/job/repository.rb
+++ b/lib/travis/worker/job/repository.rb
@@ -68,13 +68,13 @@ module Travis
           def clone
             exec 'export GIT_ASKPASS=echo', :echo => false # this makes git interactive auth fail
             exec "mkdir -p #{dir}", :echo => false
-            exec "git clone --depth=1000 --quiet #{source} #{dir}"
+            exec "git clone --depth=1000 --quiet --recurse-submodules #{source} #{dir}"
           end
 
           # @api plugin
           def fetch
             exec 'git clean -fdx'
-            exec 'git fetch'
+            exec 'git fetch --recurse-submodules'
           end
 
           # @api plugin

--- a/test/job/build_test.rb
+++ b/test/job/build_test.rb
@@ -53,7 +53,7 @@ class JobBuildTest < Test::Unit::TestCase
       'export BAR=baz',
       'test -d .git',
       'git clean -fdx',
-      'git fetch',
+      'git fetch --recurse-submodules',
       'git checkout -qf 1234567',
       'bundle install bundler_arg=1',
       'bundle exec rake ci:before',

--- a/test/job/repository_test.rb
+++ b/test/job/repository_test.rb
@@ -28,13 +28,13 @@ class JobRepositoryTest < Test::Unit::TestCase
   test 'clone: clones the repository to the current directory' do
     repository.expects(:exec).with('export GIT_ASKPASS=echo', :echo => false)
     repository.expects(:exec).with('mkdir -p /path/to/build/dir', :echo => false)
-    repository.expects(:exec).with('git clone --depth=1000 --quiet git://github.com/svenfuchs/gem-release.git /path/to/build/dir')
+    repository.expects(:exec).with('git clone --depth=1000 --quiet --recurse-submodules git://github.com/svenfuchs/gem-release.git /path/to/build/dir')
     repository.clone
   end
 
   test 'fetch: clones the repository to the current directory' do
     repository.expects(:exec).with('git clean -fdx')
-    repository.expects(:exec).with('git fetch')
+    repository.expects(:exec).with('git fetch --recurse-submodules')
     repository.fetch
   end
 


### PR DESCRIPTION
It seems like a reasonable expectation to me that most project will need their submodules to run their test suites. (I just ran into this with Capybara, which requires an xpath submodule.)

I wasn't able to get the tests running (#4), so this is complete untested! **Edit:** Tested on Travis-CI -- it works. :)
