### PR TITLE
Gemspec requires correct file

### DIFF
--- a/travis-worker.gemspec
+++ b/travis-worker.gemspec
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 $:.unshift File.expand_path('../lib', __FILE__)
-require 'travis_worker/version'
+require 'travis/worker/version'
 
 Gem::Specification.new do |s|
   s.name         = "travis-worker"


### PR DESCRIPTION
If `travis_worker` is moved to `travis/worker`, the `require` in the gemspec should reflect that :)
