### PR TITLE
rebar eunit should be run with skip_deps=true

### DIFF
--- a/lib/travis/worker/builders/erlang.rb
+++ b/lib/travis/worker/builders/erlang.rb
@@ -16,7 +16,7 @@ module Travis
             if !self[:script].nil?
               self[:script]
             elsif rebar_config_exists?
-              './rebar eunit'
+              './rebar skip_deps=true eunit'
             else
               'make test'
             end

--- a/test/builders/erlang_builder_test.rb
+++ b/test/builders/erlang_builder_test.rb
@@ -38,7 +38,7 @@ class BuilderErlangConfigTests < BuilderErlangTestCase
   end
 
   def test_config_default_script_with_rebar
-    assert_equal('./rebar eunit', new_config(:rebar_config_exists => true).script)
+    assert_equal('./rebar skip_deps=true eunit', new_config(:rebar_config_exists => true).script)
   end
 
   def test_config_custom_script


### PR DESCRIPTION
By default rebar runs commands recursively on the project and all dependencies, which is not a desirable default for the eunit command. The correct thing to do is to run the tests for each project separately.
