### PR TITLE
Autoload Travis::Worker::Job::Helpers::Repository

### DIFF
--- a/lib/travis/worker/job.rb
+++ b/lib/travis/worker/job.rb
@@ -4,6 +4,10 @@ module Travis
       autoload :Base,       'travis/worker/job/base'
       autoload :Build,      'travis/worker/job/build'
       autoload :Config,     'travis/worker/job/config'
+
+      module Helpers
+        autoload :Repository, 'travis/worker/job/helpers/repository'
+      end
     end # Job
   end # Worker
 end # Travis


### PR DESCRIPTION
Tests failed because of this missing autoload.
