### PR TITLE
Update NodeJS worker to work with aliases, and node_js/nodejs synonymity

### DIFF
--- a/lib/travis/worker/builders/node_js.rb
+++ b/lib/travis/worker/builders/node_js.rb
@@ -6,7 +6,7 @@ module Travis
         class Config < Base::Config
           def node_js_version
             version_from_config = self[:node_js] || self[:nodejs]
-            normalize(version_from_config, '0.4.12')
+            normalize(version_from_config, '0.4')
           end
 
           def package_exists?

--- a/test/builders/node_js_builder_test.rb
+++ b/test/builders/node_js_builder_test.rb
@@ -20,7 +20,7 @@ end
 
 class BuilderNodeJsConfigTests < BuilderNodeJsTestCase
   def test_config_default_node_js_version
-    assert_equal('0.4.12', new_config.node_js_version)
+    assert_equal('0.4', new_config.node_js_version)
   end
 
   def test_config_custom_node_js_version
@@ -68,7 +68,7 @@ class BuilderNodeJsCommandsTests < BuilderNodeJsTestCase
       once
 
     commands_any_instance.expects(:exec).
-      with("nvm use 0.4.12").
+      with("nvm use 0.4").
       once
 
     new_commands.setup_env
@@ -80,7 +80,7 @@ class BuilderNodeJsCommandsTests < BuilderNodeJsTestCase
       once
 
     commands_any_instance.expects(:exec).
-      with("nvm use 0.4.12").
+      with("nvm use 0.4").
       once
 
     commands_any_instance.expects(:exec).
@@ -96,7 +96,7 @@ class BuilderNodeJsCommandsTests < BuilderNodeJsTestCase
       once.returns(true)
 
     commands_any_instance.expects(:exec).
-      with("nvm use 0.4.12").
+      with("nvm use 0.4").
       once
     new_commands.setup_env
   end


### PR DESCRIPTION
You can now safely use

``` yml
node_js:
  versions:
     - 0.4
     - 0.5
```

or

``` yml
nodejs:
  versions:
     - 0.4
     - 0.5
```

or 

``` yml
node_js:
  versions:
     - 0.4.12
     - 0.5.10
```

or a combination thereof.
