### PR TITLE
Fix rake task to run specs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,9 @@
 require 'rake'
-require 'rake/testtask'
+require 'rspec/core/rake_task'
 
-Rake::TestTask.new do |t|
-  t.libs << 'lib' << 'test'
-  t.pattern = 'test/**/*_test.rb'
-  t.verbose = false
+desc 'Run specs'
+RSpec::Core::RakeTask.new do |t|
+  t.pattern = './spec/**/*_spec.rb'
 end
 
 task 'travis:worker:config' do
@@ -15,5 +14,4 @@ end
 
 # task 'resque:setup' => 'travis:worker:config'
 
-task :default => :test
-
+task :default => :spec


### PR DESCRIPTION
Right now it was configured to run test unit tests, but there are none. This commit creates an RSpec rake task and makes it default.
