### PR TITLE
Add timeouts to after_success and after_failure

### DIFF
--- a/lib/travis/worker/config.rb
+++ b/lib/travis/worker/config.rb
@@ -28,7 +28,7 @@ module Travis
              :log_level => :info,
              :queue     => 'builds.common',
              :shell     => { :buffer => 0 },
-             :timeouts  => { :hard_limit => 2400, :before_install => 300, :install => 300, :before_script => 300, :script => 600, :after_script => 300, :after_success => 300, :after_failure => 300 },
+             :timeouts  => { :hard_limit => 2400, :before_install => 300, :install => 300, :before_script => 300, :script => 600, :after_script => 300, :after_success => 300, :after_failure => 300, :default => 180 },
              :vms       => { :count => 1, :_include => Vms },
              :limits    => { :log_length => 4 * 1024 * 1024 }
 

--- a/lib/travis/worker/shell/helpers.rb
+++ b/lib/travis/worker/shell/helpers.rb
@@ -132,7 +132,7 @@ module Travis
           if stage.is_a?(Numeric)
             stage
           else
-            config.timeouts[stage || :default]
+            config.timeouts[stage || :default] || config.timeouts[:default]
           end
         end
 

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -83,6 +83,10 @@ describe Travis::Worker::Config do
       config.timeouts.install.should == 300
     end
 
+    it 'default timeout is 180' do
+      config.timeouts.default.should == 180
+    end
+
     it 'queue defaults to builds' do
       config.queue.should == 'builds.common'
     end


### PR DESCRIPTION
The after_success and after_failure scripts run in their own stages, but
they have no timeouts. This means that scripts in these stages can get
the build running "forever", eventually hitting the hard timeout and
then restarting.

(This is what causes my travis-lite build to loop and never, ever stop. Sorry about that).
