### PR TITLE
Bump worker hard limit timeout

### DIFF
--- a/lib/travis/worker/config.rb
+++ b/lib/travis/worker/config.rb
@@ -28,7 +28,7 @@ module Travis
              :log_level => :info,
              :queue     => 'builds.common',
              :shell     => { :buffer => 0 },
-             :timeouts  => { :hard_limit => 2400, :before_install => 300, :install => 300, :before_script => 300, :script => 600, :after_script => 300, :after_success => 300, :after_failure => 300, :default => 180 },
+             :timeouts  => { :hard_limit => 3000, :before_install => 300, :install => 300, :before_script => 300, :script => 600, :after_script => 300, :after_success => 300, :after_failure => 300, :default => 180 },
              :vms       => { :count => 1, :_include => Vms },
              :limits    => { :log_length => 4 * 1024 * 1024 }
 


### PR DESCRIPTION
This should always be bigger than the other timeouts added together.

/cc @joshk
