### PR TITLE
Increase 'install' timeout

### DIFF
--- a/config/worker.ruby.yml
+++ b/config/worker.ruby.yml
@@ -3,6 +3,6 @@ shell:
   buffer: 0.5
 timeouts:
   before_install: 600
-  install: 600
+  install: 2000
   before_script: 600
   script: 1500


### PR DESCRIPTION
A lot of Travis repos take a long time to build dependencies in the 'install' stage.
