### PR TITLE
Handle language specified as an array.

### DIFF
--- a/lib/travis/worker/virtual_machine/blue_box.rb
+++ b/lib/travis/worker/virtual_machine/blue_box.rb
@@ -130,6 +130,7 @@ module Travis
         end
 
         def template_for_language(lang)
+          lang = Array(lang).first
           mapping = if lang
             language_mappings[lang] || lang.gsub('_', '-')
           else


### PR DESCRIPTION
If someone does that it'll cause every worker process to error out and not recover.

Note that this tiny change is currently custom-patched on our current set of pro workers. The customer has changed their travis.yml accordingly, but just to be sure :)
