### PR TITLE
move rescueing compile errors to travis-worker

### DIFF
--- a/lib/travis/worker/job/runner.rb
+++ b/lib/travis/worker/job/runner.rb
@@ -31,7 +31,7 @@ module Travis
 
         class ConnectionError < StandardError; end
 
-        class CompileError < StandardError
+        class ScriptCompileError < StandardError
           attr_reader :original
 
           def initialize(msg, original = $!)


### PR DESCRIPTION
@joshk please ... rspec is broken on travis-build and i can't see any reason why this can't just be moved here

tests are broken on master and i don't see any tests for `generate_script` and/or `job/runner`
