### PR TITLE
Log number of active workers when gracefully shutting down

### DIFF
--- a/lib/travis/worker/application.rb
+++ b/lib/travis/worker/application.rb
@@ -153,7 +153,7 @@ module Travis
       end
 
       def active_workers
-        workers.status.map { |status| status[:state] }.select { |state| state == :stopped || state == :errored }.count
+        workers.status.map { |status| status[:state] }.reject {|state| [:stopped, :errored].include?(state)}.count
       end
     end
   end


### PR DESCRIPTION
This allows to better monitor how many jobs are still running for an active worker. To reduce the log noise a bit, I've increased the sleep to 10 seconds.
