### PR TITLE
Specify a source for Librato

### DIFF
--- a/lib/travis/worker/application.rb
+++ b/lib/travis/worker/application.rb
@@ -143,7 +143,7 @@ module Travis
       def start_metriks
         librato = Travis::Worker.config.librato
         if librato
-          @reporter = Metriks::Reporter::LibratoMetrics.new(librato['email'], librato['token'])
+          @reporter = Metriks::Reporter::LibratoMetrics.new(librato['email'], librato['token'], :source => Travis::Worker.config.host)
           @reporter.start
         end
       end


### PR DESCRIPTION
Allows us to track metrics down to a single process if we need to,
as the host is specific to every process.
