### PR TITLE
Print warning if we're unable to find/parse config

### DIFF
--- a/lib/travis/worker/job/runner.rb
+++ b/lib/travis/worker/job/runner.rb
@@ -66,6 +66,7 @@ module Travis
         end
 
         def setup
+          warn_about_configuration
           setup_log_streaming
           start_session
         rescue Net::SSH::AuthenticationFailed, Errno::ECONNREFUSED, Timeout::Error => e
@@ -100,6 +101,18 @@ module Travis
           exit_exec!
           sleep 2
           session.close
+        end
+
+        def warn_about_configuration
+          case payload["config"][:".result"]
+          when "parse_error"
+            announce "WARNING: An error occured while trying to parse your .travis.yml file."
+            announce "  Please make sure that the file is valid YAML."
+            announce "  Build will be treated as if no .travis.yml file exists"
+          when "not_found"
+            announce "WARNING: We were unable to find a .travis.yml file. This may not be what you"
+            announce "  want. Build will be run with default settings."
+          end
         end
 
         def upload_and_run_script


### PR DESCRIPTION
See travis-ci/travis-ci#814, and probably many more issues.

This is a very simple initial implementation for handling this problem.
We may want to actually put the parse error in the payload at some point
and print that, or maybe validate the .travis.yml file somehow, but this
works as a beginning.
