### PR TITLE
Error a build if we couldn't parse the YAML file

### DIFF
--- a/lib/travis/worker/instance.rb
+++ b/lib/travis/worker/instance.rb
@@ -239,9 +239,7 @@ module Travis
 
         vm.sandboxed(language: job_language) do
           runner = Job::Runner.new(self.payload, vm.session, reporter, vm.full_name, config.timeouts.hard_limit, name)
-          runner.setup
-          runner.start
-          runner.stop
+          runner.run
         end
       ensure
         runner.terminate if runner && runner.alive?


### PR DESCRIPTION
Fixes travis-ci/travis-ci#814.

While there is an argument that no .travis.yml file should make the
build run using default settings for legacy reasons, if a user does
provide a .travis.yml file and it's not valid YAML then I can't think of
a reason why the user still would want the build to be run.
