### PR TITLE
Use build script from payload if one is provided

### DIFF
--- a/lib/travis/worker/job/runner.rb
+++ b/lib/travis/worker/job/runner.rb
@@ -131,7 +131,7 @@ module Travis
 
         def upload_and_run_script
           info "uploading build.sh"
-          session.upload_file("~/build.sh", compile_script)
+          session.upload_file("~/build.sh", payload['script'] || compile_script)
 
           info "setting +x permission on build.sh"
           session.exec("chmod +x ~/build.sh")


### PR DESCRIPTION
This allows us to move the compilation of build scripts to hub, which again means that updating travis-build doesn't require us to update all the workers, allowing for quicker and more easy deployments of travis-build.

/cc @joshk
