### PR TITLE
Made decoded_payload a Hashr in instance_spec

### DIFF
--- a/spec/instance_spec.rb
+++ b/spec/instance_spec.rb
@@ -23,7 +23,7 @@ describe Travis::Worker::Instance do
   
   let(:metadata)        { stub('metadata', :ack => nil, :routing_key => "builds.common") }
 
-  let(:decoded_payload) { { 'id' => 1, 'repository' => { 'slug' => 'joshk/fun_times' }, 'job' => { 'id' => 123 }, 'config' => { 'language' => 'ruby' }, 'uuid' => 'a-uuid'} }
+  let(:decoded_payload) { Hashr.new('id' => 1, 'repository' => { 'slug' => 'joshk/fun_times' }, 'job' => { 'id' => 123 }, 'config' => { 'language' => 'ruby' }, 'uuid' => 'a-uuid') }
  
   let(:payload)         { MultiJson.encode(decoded_payload) }
 


### PR DESCRIPTION
Instance.rb expects the payload it uses to be a Hashr. Since we stub out payload to be decoded_payload, bypassing the `decode` method, we need to manually create it as a `Hashr`.
