### PR TITLE
Duplicate and template handling

### DIFF
--- a/lib/travis/worker/virtual_machine/blue_box.rb
+++ b/lib/travis/worker/virtual_machine/blue_box.rb
@@ -212,6 +212,10 @@ module Travis
                 match[1] == "#{Worker.config.host.split('.').first}-#{Process.pid}-#{name}"
               end
             end
+          rescue Excon::Errors::HTTPStatusError => e
+            warn "could not retrieve the current VM list : #{e.inspect}"
+            mark_api_error(e)
+            raise
           end
 
           def instrument


### PR DESCRIPTION
If when starting a new test run, a duplicate VM is detected, then the VM is destroyed first.
