### PR TITLE
fix(runner): don't mark the job as finished if it's being restarted

### DIFF
--- a/lib/travis/worker/job/runner.rb
+++ b/lib/travis/worker/job/runner.rb
@@ -99,13 +99,16 @@ module Travis
             warn "[Possible VM Error] The job has been requeued as no output has been received and the ssh connection could not be closed"
           end
           announce("\n\n#{e.message}\n\n")
+          result = 'errored'
         rescue Utils::Buffer::OutputLimitExceededError, ScriptCompileError => e
           warn "build error : #{e.class}, #{e.message}"
           warn "  #{e.backtrace.join("\n  ")}"
           stop
           announce("\n\n#{e.message}\n\n")
+          result = 'errored'
         rescue Timeout::Error => e
           timedout
+          result = 'errored'
         rescue IOError, Errno::ECONNREFUSED => e
           connection_error
         ensure
@@ -114,7 +117,7 @@ module Travis
             reporter.send_log(job_id, "\n\nDone: Job Cancelled\n")
             result = 'canceled'
           end
-          notify_job_finished(result)
+          notify_job_finished(result) if result
         end
 
         def stop


### PR DESCRIPTION
This means that the job can be marked as finished immediately after it was
restarted, which can cause multiple notifications or errors when the build is
checking if all jobs are finished (when some are actually marked as created).

Fix travis-ci/travis-ci#1858.
