### PR TITLE
create the reporter early, keep the reporter, but reset the part number

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ GIT
 
 GIT
   remote: https://github.com/travis-ci/travis-build
-  revision: 24ac4806d333d182687bae411fd1e016e6a93a6b
+  revision: 9851cd08297e1f8387fb0b371cf5ff3e31dd5cbd
   specs:
     travis-build (0.0.1)
 
@@ -55,11 +55,11 @@ GEM
     coderay (1.1.0)
     diff-lcs (1.2.5)
     docile (1.1.3)
-    docker-api (1.11.0)
+    docker-api (1.11.1)
       archive-tar-minitar
       excon (>= 0.34.0)
       json
-    excon (0.36.0)
+    excon (0.37.0)
     faraday (0.7.6)
       addressable (~> 2.2)
       multipart-post (~> 1.1)
@@ -88,9 +88,9 @@ GEM
       net-ssh (>= 2.6.5)
     net-ssh (2.9.1)
     nokogiri (1.5.11-java)
-    pry (0.9.12.6-java)
-      coderay (~> 1.0)
-      method_source (~> 0.8)
+    pry (0.10.0-java)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
       slop (~> 3.4)
       spoon (~> 0.0)
     rack (1.5.2)
@@ -104,7 +104,7 @@ GEM
     rspec-expectations (3.0.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.0.0)
-    rspec-mocks (3.0.0)
+    rspec-mocks (3.0.1)
       rspec-support (~> 3.0.0)
     rspec-support (3.0.0)
     ruby-hmac (0.4.0)

--- a/lib/travis/worker/instance.rb
+++ b/lib/travis/worker/instance.rb
@@ -27,7 +27,7 @@ module Travis
 
       attr_accessor :state
       attr_reader :name, :vm, :broker_connection, :queue, :queue_name,
-                  :subscription, :config, :payload, :last_error, :observers
+                  :subscription, :config, :payload, :last_error, :observers, :reporter
 
       def initialize(name, vm, broker_connection, queue_name, config, observers = [])
         raise ArgumentError, "worker name cannot be nil!" if name.nil?
@@ -41,6 +41,9 @@ module Travis
         @broker_connection = broker_connection
         @config            = config
         @observers         = Array(observers)
+
+        # create the reporter early so it is not created within the `process` callback
+        @reporter = Reporter.new(name, broker_connection.create_channel, broker_connection.create_channel)
       end
 
       def start
@@ -79,7 +82,6 @@ module Travis
         # puts error.message, error.backtrace
         error_build(error, message)
       ensure
-        reset_reporter
         @job_canceled = false
       end
 
@@ -207,7 +209,7 @@ module Travis
 
         restart_job if opts[:restart]
 
-        message.ack
+        message.ack # TODO: check if the channel is open
 
         @payload = nil
 
@@ -229,15 +231,6 @@ module Travis
         set :ready
       end
       log :error, :as => :debug
-
-      def reporter
-        @reporter ||= Reporter.new(name, broker_connection.create_channel, broker_connection.create_channel)
-      end
-
-      def reset_reporter
-        reporter.close if @reporter
-        @reporter = nil
-      end
 
       def host
         Travis::Worker.config.host


### PR DESCRIPTION
@joshk going through the changes that went into master meanwhile, and their differences to my te/docker branches I have found this is missing from master.

It makes sure the worker reconnects to rabbit after connection loss. Please merge :)
