### PR TITLE
Use travis-support/master

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 # ruby '1.9.3', engine: 'jruby', engine_version: '1.7.12'
 
 gem 'travis-build',     git: 'https://github.com/travis-ci/travis-build'
-gem 'travis-support',   git: 'https://github.com/travis-ci/travis-support', ref: 'f1cbac9'
+gem 'travis-support',   git: 'https://github.com/travis-ci/travis-support'
 
 gem 'celluloid',        git: 'https://github.com/celluloid/celluloid', ref: '5a56056'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,8 +20,7 @@ GIT
 
 GIT
   remote: https://github.com/travis-ci/travis-support
-  revision: f1cbac986f09ee4045b3d381b6519adb95ab5695
-  ref: f1cbac9
+  revision: 033d9b993d4c8b08af8d86a725ee34539cf0b979
   specs:
     travis-support (0.0.1)
 

--- a/lib/travis/worker/application.rb
+++ b/lib/travis/worker/application.rb
@@ -6,6 +6,7 @@ require 'travis/worker/pool'
 require 'travis/worker/application/commands/dispatcher'
 require 'travis/worker/application/heart'
 require 'travis/worker/application/remote'
+require 'travis/support/amqp'
 
 module Travis
   module Worker
@@ -14,7 +15,6 @@ module Travis
 
       def initialize
         Travis.logger.level = Logger.const_get(config.log_level.to_s.upcase)
-        Travis.logger.formatter = proc { |*args| Travis::Logging::Format.format(*args) }
 
         Travis::Amqp.config = config.amqp
 

--- a/lib/travis/worker/config.rb
+++ b/lib/travis/worker/config.rb
@@ -20,18 +20,19 @@ module Travis
         end
       end
 
-      define :amqp      => { :username => 'guest', :password => 'guest', :host => 'localhost' },
-             :heartbeat => { :interval => 10 },
-             :log_level => :info,
-             :queue     => 'builds.linux',
-             :logging_channel => 'reporting.jobs.logs',
-             :shell     => { :buffer => 0.5 },
-             :timeouts  => { :build_script => 5, :hard_limit => 50 * 60, :log_silence => 10 * 60 },
-             :shutdown_timeout => 3600,
-             :vms       => { :provider => 'blue_box', :count => 1, :_include => Vms },
-             :limits    => { :log_length => 4, :log_chunk_size => 9216 },
-             :language_mappings => { },
-             :build     => {}
+        define amqp:      { username: 'guest', password: 'guest', host: 'localhost' },
+               heartbeat: { interval: 10 },
+               log_level: 'info',
+               logger:    { time_format: '%Y-%m-%dT%H:%M:%S.%6N%:z', process_id: true, thread_id: true },
+               queue:     'builds.linux',
+               logging_channel: 'reporting.jobs.logs',
+               shell:     { buffer: 0.5 },
+               timeouts:  { build_script: 5, hard_limit: 50 * 60, log_silence: 10 * 60 },
+               shutdown_timeout: 3600,
+               vms:       { provider: 'blue_box', count: 1, _include: Vms },
+               limits:    { log_length: 4, log_chunk_size: 9216 },
+               language_mappings: { },
+               build:     {}
 
       def name
         @name ||= host.split('.').first


### PR DESCRIPTION
This makes the worker use current travis-support/master.

The log format very slightly changes. Before:

Before:
```
2014-10-08T13:35:19.104000+00:00 5613 DEBUG TID=ees [linux-1:worker:instance] done: prepare
```

After:
```
2014-10-08T16:20:34.189000+00:00 D PID=23938 TID=9444 [linux-1:worker:instance] done: prepare
```