### PR TITLE
Adds Blue Box VSH ID to boot timeout metrics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,8 @@ gem 'multi_json',       '~> 1.2.0'
 gem 'json'
 gem 'coder'
 
-gem 'fog'
+# Use my fork until https://github.com/fog/fog/pull/3212 is merged and released
+gem 'fog',             git: 'https://github.com/BanzaiMan/fog', branch: 'ha-feature-bluebox-vhs_id'
 gem 'travis-saucelabs-api', '~> 0.0'
 gem 'docker-api'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,20 @@
 GIT
+  remote: https://github.com/BanzaiMan/fog
+  revision: 253672c451738a4f3a7724638b2a088689b06582
+  branch: ha-feature-bluebox-vhs_id
+  specs:
+    fog (1.24.0)
+      fog-brightbox
+      fog-core (~> 1.24)
+      fog-json
+      fog-radosgw (>= 0.0.2)
+      fog-sakuracloud (>= 0.0.4)
+      fog-softlayer
+      fog-xml
+      ipaddress (~> 0.5)
+      nokogiri (~> 1.5, >= 1.5.11)
+
+GIT
   remote: https://github.com/celluloid/celluloid
   revision: 5a560561b49241fc84c3b414bb6652826ce8ea71
   ref: 5a56056
@@ -55,14 +71,7 @@ GEM
     faraday_middleware (0.9.1)
       faraday (>= 0.7.4, < 0.10)
     ffi (1.9.3-java)
-    fog (1.23.0)
-      fog-brightbox
-      fog-core (~> 1.23)
-      fog-json
-      fog-softlayer
-      ipaddress (~> 0.5)
-      nokogiri (~> 1.5, >= 1.5.11)
-    fog-brightbox (0.5.0)
+    fog-brightbox (0.6.1)
       fog-core (~> 1.22)
       fog-json
       inflecto
@@ -75,9 +84,19 @@ GEM
       net-ssh (>= 2.1.3)
     fog-json (1.0.0)
       multi_json (~> 1.0)
-    fog-softlayer (0.3.17)
+    fog-radosgw (0.0.3)
+      fog-core (>= 1.21.0)
+      fog-json
+      fog-xml (>= 0.0.1)
+    fog-sakuracloud (0.1.1)
       fog-core
       fog-json
+    fog-softlayer (0.3.22)
+      fog-core
+      fog-json
+    fog-xml (0.1.0)
+      fog-core
+      nokogiri (~> 1.5, >= 1.5.11)
     formatador (0.2.5)
     hashr (0.0.22)
     hitimes (1.2.2)
@@ -94,7 +113,7 @@ GEM
       atomic (~> 1.0)
       avl_tree (~> 1.1.2)
       hitimes (~> 1.1)
-    mime-types (2.3)
+    mime-types (2.4.3)
     mini_portile (0.6.0)
     mocha (0.11.4)
       metaclass (~> 0.0.1)
@@ -159,7 +178,7 @@ DEPENDENCIES
   coder
   docker-api
   faraday (~> 0.7.5)
-  fog
+  fog!
   hashr (~> 0.0.18)
   json
   march_hare (= 2.2.0)


### PR DESCRIPTION
When https://github.com/fog/fog/pull/3212 is merged and released,
we should switch back to the mainstream 'fog'.
