### PR TITLE
Do not memoize @template_list

### DIFF
--- a/lib/travis/worker/virtual_machine/blue_box.rb
+++ b/lib/travis/worker/virtual_machine/blue_box.rb
@@ -151,14 +151,13 @@ module Travis
         end
 
         def latest_templates(group = nil, dist = nil)
-          return @template_list if @template_list
           template_list = {}
 
           grouped_templates(group, dist).each do |k,v|
             template_list[k] = v.sort { |a, b| b.created <=> a.created }.first
           end
 
-          @template_list = template_list
+          template_list
         end
 
         def template_for_language(lang, group = nil, dist = nil)


### PR DESCRIPTION
This memoization effectively ties the list of selectable templates to
the ones that we memoize on the first API call when the app is
restarted.
