### PR TITLE
Update gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,8 +17,7 @@ gem 'multi_json',       '~> 1.2.0'
 gem 'json'
 gem 'coder'
 
-# Use my fork until https://github.com/fog/fog/pull/3212 is merged and released
-gem 'fog',             git: 'https://github.com/BanzaiMan/fog', branch: 'ha-feature-bluebox-vhs_id'
+gem 'fog',              '~> 1.25.0'
 gem 'travis-saucelabs-api', '~> 0.0'
 gem 'docker-api'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,4 @@
 GIT
-  remote: https://github.com/BanzaiMan/fog
-  revision: 253672c451738a4f3a7724638b2a088689b06582
-  branch: ha-feature-bluebox-vhs_id
-  specs:
-    fog (1.24.0)
-      fog-brightbox
-      fog-core (~> 1.24)
-      fog-json
-      fog-radosgw (>= 0.0.2)
-      fog-sakuracloud (>= 0.0.4)
-      fog-softlayer
-      fog-xml
-      ipaddress (~> 0.5)
-      nokogiri (~> 1.5, >= 1.5.11)
-
-GIT
   remote: https://github.com/celluloid/celluloid
   revision: 5a560561b49241fc84c3b414bb6652826ce8ea71
   ref: 5a56056
@@ -44,6 +28,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    CFPropertyList (2.2.8)
     activesupport (3.2.19)
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
@@ -71,11 +56,28 @@ GEM
     faraday_middleware (0.9.1)
       faraday (>= 0.7.4, < 0.10)
     ffi (1.9.3-java)
+    fission (0.5.0)
+      CFPropertyList (~> 2.2)
+    fog (1.25.0)
+      fog-brightbox (~> 0.4)
+      fog-core (~> 1.25)
+      fog-json
+      fog-profitbricks
+      fog-radosgw (>= 0.0.2)
+      fog-sakuracloud (>= 0.0.4)
+      fog-softlayer
+      fog-terremark
+      fog-vmfusion
+      fog-voxel
+      fog-xml (~> 0.1.1)
+      ipaddress (~> 0.5)
+      nokogiri (~> 1.5, >= 1.5.11)
+      opennebula
     fog-brightbox (0.6.1)
       fog-core (~> 1.22)
       fog-json
       inflecto
-    fog-core (1.24.0)
+    fog-core (1.25.0)
       builder
       excon (~> 0.38)
       formatador (~> 0.2)
@@ -84,6 +86,10 @@ GEM
       net-ssh (>= 2.1.3)
     fog-json (1.0.0)
       multi_json (~> 1.0)
+    fog-profitbricks (0.0.1)
+      fog-core
+      fog-xml
+      nokogiri
     fog-radosgw (0.0.3)
       fog-core (>= 1.21.0)
       fog-json
@@ -91,10 +97,19 @@ GEM
     fog-sakuracloud (0.1.1)
       fog-core
       fog-json
-    fog-softlayer (0.3.22)
+    fog-softlayer (0.3.24)
       fog-core
       fog-json
-    fog-xml (0.1.0)
+    fog-terremark (0.0.2)
+      fog-core
+      fog-xml
+    fog-vmfusion (0.0.1)
+      fission
+      fog-core
+    fog-voxel (0.0.1)
+      fog-core
+      fog-xml
+    fog-xml (0.1.1)
       fog-core
       nokogiri (~> 1.5, >= 1.5.11)
     formatador (0.2.5)
@@ -114,7 +129,7 @@ GEM
       avl_tree (~> 1.1.2)
       hitimes (~> 1.1)
     mime-types (2.4.3)
-    mini_portile (0.6.0)
+    mini_portile (0.6.1)
     mocha (0.11.4)
       metaclass (~> 0.0.1)
     multi_json (1.2.0)
@@ -122,9 +137,12 @@ GEM
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (2.9.1)
-    nokogiri (1.6.3.1)
-      mini_portile (= 0.6.0)
-    nokogiri (1.6.3.1-java)
+    nokogiri (1.6.4.1)
+      mini_portile (~> 0.6.0)
+    nokogiri (1.6.4.1-java)
+    opennebula (4.10.0)
+      json
+      nokogiri
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -178,7 +196,7 @@ DEPENDENCIES
   coder
   docker-api
   faraday (~> 0.7.5)
-  fog!
+  fog (~> 1.25.0)
   hashr (~> 0.0.18)
   json
   march_hare (= 2.2.0)


### PR DESCRIPTION
Most notably, `fog` to `~> 1.25.0`, so that
`Travis::Worker::VirtualMachine::Server#vsh_id` can be found from the release
