### PR TITLE
Bring back logging PID and TID

### DIFF
--- a/lib/travis/worker/config.rb
+++ b/lib/travis/worker/config.rb
@@ -20,19 +20,20 @@ module Travis
         end
       end
 
-      define :amqp      => { :username => 'guest', :password => 'guest', :host => 'localhost' },
-             :heartbeat => { :interval => 10 },
-             :log_level => :info,
-             :queue     => 'builds.linux',
-             :logging_channel => 'reporting.jobs.logs',
-             :shell     => { :buffer => 0.5 },
-             :timeouts  => { :build_script => 5, :hard_limit => 50 * 60, :log_silence => 10 * 60 },
-             :shutdown_timeout => 3600,
-             :vms       => { :provider => 'blue_box', :count => 1, :_include => Vms },
-             :limits    => { :log_length => 4, :log_chunk_size => 9216 },
-             :language_mappings => { },
-             :build     => {},
-             :sentry    => {}
+      define amqp:      { username: 'guest', password: 'guest', host: 'localhost' },
+             heartbeat: { interval: 10 },
+             log_level: :info,
+             logger:    { process_id: true, thread_id: true },
+             queue:     'builds.linux',
+             logging_channel: 'reporting.jobs.logs',
+             shell:     { buffer: 0.5 },
+             timeouts:  { build_script: 5, hard_limit: 50 * 60, log_silence: 10 * 60 },
+             shutdown_timeout: 3600,
+             vms:       { provider: 'blue_box', count: 1, _include: Vms },
+             limits:    { log_length: 4, log_chunk_size: 9216 },
+             language_mappings: { },
+             build:     {},
+             sentry:    {}
 
       def name
         @name ||= host.split('.').first

--- a/spec/application_spec.rb
+++ b/spec/application_spec.rb
@@ -52,14 +52,24 @@ describe Travis::Worker::Application do
       Travis.logger = Logger.new(io)
     end
 
-    it 'should log starting the workers' do
+    it 'logs starting the workers' do
       app.start
       expect(io.string).to match(/start/)
     end
 
-    it 'should log stopping the workers' do
+    it 'logs stopping the workers' do
       app.stop()
       expect(io.string).to match(/stop/)
+    end
+
+    it 'includes the process id' do
+      Travis.logger.info('foo')
+      expect(io.string).to match(/ PID=\d+ /)
+    end
+
+    it 'includes the thread id' do
+      Travis.logger.info('foo')
+      expect(io.string).to match(/ TID=\d+ /)
     end
   end
 end


### PR DESCRIPTION
PID and TID were lost during the sf-te merge. This brings them back by default.
