### PR TITLE
Ensure a reasonable template is selected

### DIFF
--- a/lib/travis/worker/virtual_machine/blue_box.rb
+++ b/lib/travis/worker/virtual_machine/blue_box.rb
@@ -50,7 +50,9 @@ module Travis
 
         def create_server(opts = {})
           info "opts: #{opts}"
-          template = template_for_language(opts[:language], opts[:group], opts[:dist])
+          template = template_for_language(opts[:language], opts[:group], opts[:dist]) ||
+            template_for_language(opts[:language], nil, nil) ||
+            template_for_language(DEFAULT_TEMPLATE_LANGUAGE, nil, nil)
 
           info "template: #{template.info}"
 
@@ -167,13 +169,13 @@ module Travis
           mapping = if lang
             language_mappings[lang] || lang.gsub('_', '-')
           else
-            'ruby'
+            DEFAULT_TEMPLATE_LANGUAGE
           end
 
           select_template(mapping, group, dist)
         rescue => e
           error "Error figuring out what template to use: #{e.inspect}"
-          latest_templates(group)[[nil, nil, 'ruby']]
+          latest_templates(group)[[nil, nil, DEFAULT_TEMPLATE_LANGUAGE]]
         end
 
         def destroy_server(opts = {})


### PR DESCRIPTION
In the event of a BB block template rename, it is possible that
a job waiting for a VM to go into an infinite template selection
loop where `#create_server` throws a `NoMethodError` because
`#template_for_language()` is `nil`.