### PR TITLE
Notify about job:received

### DIFF
--- a/lib/travis/worker/instance.rb
+++ b/lib/travis/worker/instance.rb
@@ -90,6 +90,7 @@ module Travis
         info "starting job slug:#{self.payload['repository']['slug']} id:#{self.payload['job']['id']}"
         info "this is a requeued message" if message.redelivered?
 
+        notify_job_received
         run_job
 
         finish(message)
@@ -281,6 +282,10 @@ module Travis
       def timeout(type)
         timeout = payload.timeouts && payload.timeouts.send(type) || config.timeouts.send(type)
         timeout.to_i
+      end
+
+      def notify_job_received
+        reporter.notify_job_received(self.payload['job']['id'])
       end
 
       def restart_job

--- a/lib/travis/worker/reporter.rb
+++ b/lib/travis/worker/reporter.rb
@@ -70,8 +70,12 @@ module Travis
         send_log(job_id, "", true)
       end
 
+      def notify_job_received(job_id)
+        notify('job:test:receive', id: job_id, state: 'received', received_at: Time.now.utc, worker: Travis::Worker.config.hostname)
+      end
+
       def notify_job_started(job_id)
-        notify('job:test:start',  id: job_id, state: 'started', started_at: Time.now.utc)
+        notify('job:test:start', id: job_id, state: 'started', started_at: Time.now.utc)
       end
 
       def notify_job_finished(job_id, result)


### PR DESCRIPTION
Tested on Enterprise. Should be good to be merged once web doesn't raise errors on `build:received` and `job:received` messages.