### PR TITLE
Reduce wasted checks against Blue Box API

### DIFF
--- a/lib/travis/worker/virtual_machine/blue_box.rb
+++ b/lib/travis/worker/virtual_machine/blue_box.rb
@@ -73,7 +73,9 @@ module Travis
           @server = connection.servers.create(opts)
           info "Booting #{server.hostname} (#{ip_address}) on #{server.vsh_id}"
           instrument do
-            Fog.wait_for(300, 3) do
+            # Blue Box block/vps spinup time is 30-40 seconds
+            sleep(24)
+            Fog.wait_for(300, 6) do
               begin
                 server.reload
                 server.ready?


### PR DESCRIPTION
Analysis of Travis CI use of the Blue Box API reveals that an average of 11 calls are made after every block/server spinup, to determine if a server is ready for use.

As the wait interval between API checks is 3 seconds, but a server typically isn't ready for 30-40 seconds, the first ~10 calls are overhead without benefit.

The Fog `wait_for` command performs a sleep between wait intervals (see https://github.com/fog/fog-core/blob/master/lib/fog/core/wait_for.rb#L11). This pull request introduces a first sleep of 24 seconds, to remove 8 unneeded calls to the API, per server.

This pull request also lengthens the wait interval to 6 seconds, to further reduce unneeded calls.

In theory this pull request should reduce the processing load of worker instances in charge of server provisioning, allowing more servers to be provisioned per worker.

And on the Blue Box API side, this should greatly increase responsiveness and capacity for beneficial API actions.

Thank you for considering.